### PR TITLE
4 automatic schema registration retrieval

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.3"
+current_version = "0.0.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/django_kafka/__init__.py
+++ b/django_kafka/__init__.py
@@ -13,7 +13,7 @@ from django_kafka.registry import ConsumersRegistry
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 __all__ = [
     "autodiscover",

--- a/django_kafka/tests/test_topic.py
+++ b/django_kafka/tests/test_topic.py
@@ -186,31 +186,6 @@ class AvroTopicTestCase(TestCase):
     def setUp(self):
         self.topic = ATopic()
 
-    def test_key_schema(self, mock_kafka_schema_client):
-        schema = self.topic.key_schema
-
-        # return value of the schema.get_latest_version method call
-        self.assertEqual(
-            schema,
-            mock_kafka_schema_client.get_latest_version.return_value,
-        )
-        # get_latest_version called with right arguments
-        mock_kafka_schema_client.get_latest_version.assert_called_once_with(
-            f"{self.topic.name}-key",
-        )
-
-    def test_value_schema(self, mock_kafka_schema_client):
-        schema = self.topic.value_schema
-        # return value of the schema.get_latest_version method call
-        self.assertEqual(
-            schema,
-            mock_kafka_schema_client.get_latest_version.return_value,
-        )
-        # called with right arguments
-        mock_kafka_schema_client.get_latest_version.assert_called_once_with(
-            f"{self.topic.name}-value",
-        )
-
     @patch("django_kafka.topic.AvroSerializer")
     def test_key_serializer(self, mock_avro_serializer, mock_kafka_schema_client):
         key_serializer = self.topic.key_serializer
@@ -220,7 +195,8 @@ class AvroTopicTestCase(TestCase):
         # instance was initialized with right arguments
         mock_avro_serializer.assert_called_once_with(
             mock_kafka_schema_client,
-            schema_str=self.topic.key_schema.schema.schema_str,
+            schema_str=self.topic.key_schema,
+            conf=self.topic.serializer_conf,
         )
 
     @patch("django_kafka.topic.AvroDeserializer")
@@ -232,7 +208,7 @@ class AvroTopicTestCase(TestCase):
         # instance was initialized with right arguments
         mock_avro_deserializer.assert_called_once_with(
             mock_kafka_schema_client,
-            schema_str=self.topic.key_schema.schema.schema_str,
+            schema_str=self.topic.key_schema,
         )
 
     @patch("django_kafka.topic.AvroSerializer")
@@ -244,7 +220,8 @@ class AvroTopicTestCase(TestCase):
         # instance was initialized with right arguments
         mock_avro_serializer.assert_called_once_with(
             mock_kafka_schema_client,
-            schema_str=self.topic.key_schema.schema.schema_str,
+            schema_str=self.topic.key_schema,
+            conf=self.topic.serializer_conf,
         )
 
     @patch("django_kafka.topic.AvroDeserializer")
@@ -256,5 +233,5 @@ class AvroTopicTestCase(TestCase):
         # instance was initialized with right arguments
         mock_avro_deserializer.assert_called_once_with(
             mock_kafka_schema_client,
-            schema_str=self.topic.key_schema.schema.schema_str,
+            schema_str=self.topic.key_schema,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-kafka"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
     "django>=4.0,<6.0",
     "confluent-kafka[avro, schema-registry]==2.4.0"


### PR DESCRIPTION
For Producing (serializing), `Topic` subclasses must return a schema from `key_schema` and `value_schema`, otherwise `AvroSerializer` will produce an error.

For Consuming (deserialzing), `Topic` subclasses can leave `key_schema` and `value_schema` returning None, and `AvroDeserializer` will fetch the right schema based on the message contents. Or they can optionally override it to use a different schema.

Also `serializer_conf` added as a parameter to `Topic` so serialization conf can be adjusted (e.g. adjusting `subject.name.strategy`).