### PR TITLE
feat: `./manage.py kafka_connect` exists now with CommandError in cas…

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.5.4"
+current_version = "0.5.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.5 (2024-11-06)
+* `./manage.py kafka_connect` command now will exit with `CommandError` in case of any exception.
+* New `@substitute_error(errors: Iterable[Type[Exception]], substitution: Type[Exception])` decorator to substitute exceptions.
+
 ## 0.5.2 (2024-10-17)
 * Added `producer.suppress` decorator.
 * Renamed `KafkaSkipModel` to `KafkaConnectSkipModel`.

--- a/django_kafka/__init__.py
+++ b/django_kafka/__init__.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 __all__ = [
     "autodiscover",

--- a/django_kafka/management/commands/errors.py
+++ b/django_kafka/management/commands/errors.py
@@ -1,0 +1,15 @@
+from collections.abc import Iterable
+from functools import wraps
+from typing import Callable, Type
+
+
+def substitute_error(errors: Iterable[Type[Exception]], substitution: Type[Exception]) -> Callable:
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except tuple(errors) as original_error:
+                raise substitution from original_error
+        return wrapper
+    return decorator

--- a/django_kafka/management/commands/kafka_connect.py
+++ b/django_kafka/management/commands/kafka_connect.py
@@ -8,6 +8,7 @@ from requests.exceptions import RetryError
 from django_kafka import kafka
 from django_kafka.exceptions import DjangoKafkaError
 from django_kafka.connect.connector import Connector, ConnectorStatus
+from django_kafka.management.commands.errors import substitute_error
 from django_kafka.utils import retry
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,7 @@ class Command(BaseCommand):
         self.connectors: list[str] = []
         self.has_failures = False
 
+    @substitute_error([Exception], CommandError)
     def handle(self, connector, **options):
         if options["list"]:
             self.list_connectors()

--- a/django_kafka/tests/connect/test_substitute_error.py
+++ b/django_kafka/tests/connect/test_substitute_error.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+from django.core.management import CommandError
+from django.test import SimpleTestCase
+
+from django_kafka.management.commands.errors import substitute_error
+
+
+class SubstituteErrorTestCase(SimpleTestCase):
+    def test_substitute(self):
+        class CustomException(Exception):
+            pass
+
+        errors = [ValueError, KeyError, CustomException]
+        decorator = substitute_error(errors, CommandError)
+
+        for error in errors:
+            func = Mock(side_effect=error)
+
+            with self.assertRaises(CommandError):
+                decorator(func)()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-kafka"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
     "django>=4.0,<6.0",
     "confluent-kafka[avro, schema-registry]==2.4.0"


### PR DESCRIPTION
…e of any Exception.

feat: introduce `substitute_error` decorator.

refs #34