### PR TITLE
fix: prevent `DjangoKafka.run_consumers` from starting the process if…

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.5.5"
+current_version = "0.5.6"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.6 (2024-11-13)
+* Fix `DjangoKafka.run_consumers` failing when there are no consumers in the registry.
+
 ## 0.5.5 (2024-11-06)
 * `./manage.py kafka_connect` command now will exit with `CommandError` in case of any exception.
 * New `@substitute_error(errors: Iterable[Type[Exception]], substitution: Type[Exception])` decorator to substitute exceptions.

--- a/django_kafka/__init__.py
+++ b/django_kafka/__init__.py
@@ -62,7 +62,10 @@ class DjangoKafka:
         consumer.run()
 
     def run_consumers(self, consumers: Optional[list[str]] = None):
-        consumers = consumers or list(self.consumers)
+        if not (consumers := consumers or list(self.consumers)):
+            logger.debug("No consumers in registry. Exit the process.")
+            return
+
         with Pool(processes=len(consumers)) as pool:
             try:
                 pool.map(self.run_consumer, consumers)

--- a/django_kafka/__init__.py
+++ b/django_kafka/__init__.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 __all__ = [
     "autodiscover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-kafka"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
     "django>=4.0,<6.0",
     "confluent-kafka[avro, schema-registry]==2.4.0"


### PR DESCRIPTION
… no consumers are registered.

fixes #36