### PR TITLE
Renovate

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,18 +14,16 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
         django:
-          - "4.0"
-          - "4.1"
           - "4.2"
           - "5.0"
+          - "5.1"
         exclude:
-          - python-version: "3.11"
-            django: "4.0"
-          - python-version: "3.12"
-            django: "4.0"
-          - python-version: "3.12"
-            django: "4.1"
+          - python-version: "3.13"
+            django: "4.2"
+          - python-version: "3.13"
+            django: "5.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
-django==5.0.8                                   # famous web framework
-confluent-kafka[avro, schema-registry]==2.5.0
-bump-my-version==0.26.0                         # for making releases
-ruff==0.6.1                                     # speed of light linter
-setuptools==73.0.0                              # without it PyCharm fails to index packages inside the Docker container
+bump-my-version==0.28.1
+confluent-kafka[avro, schema-registry]==2.6.1
+django==5.1.3
+ruff==0.7.4
+setuptools==75.5.0 # without it PyCharm fails to index packages inside the Docker container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "django-kafka"
 version = "0.5.8"
 dependencies = [
-    "django>=4.0,<6.0",
-    "confluent-kafka[avro, schema-registry]==2.4.0"
+    "django>=4.2,<6.0",
+    "confluent-kafka[avro, schema-registry]==2.6.0"
 ]
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
Update dependencies and add tests for Django 5.1 and Python 3.13\
Removed support for EOL Django 4.0 and 4.1

Fixes security issues
* https://github.com/RegioHelden/django-kafka/security/dependabot/9
* https://github.com/RegioHelden/django-kafka/security/dependabot/10