### PR TITLE
fix: `ModelMessageProcessor._aget_missing_relation` wrong return value.

### DIFF
--- a/django_kafka/relations_resolver/processor/model.py
+++ b/django_kafka/relations_resolver/processor/model.py
@@ -69,11 +69,11 @@ class ModelMessageProcessor(MessageProcessor):
         self,
         topic: "TopicConsumer",
         msg: "cimpl.Message",
-    ) -> bool:
+    ) -> Relation | None:
         for relation in topic.get_relations(msg):
             if not await relation.aexists():
-                return True
-        return False
+                return relation
+        return None
 
     async def ato_resolve(self) -> AsyncIterator["Relation"]:
         async for item in self.model.objects.aiter_relations_to_resolve(chunk_size=500):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["django>=4.2,<6.0", "confluent-kafka[avro, schemaregistry]>=2.9.0", "django-temporalio==1.3.0"]
+dependencies = ["django>=4.2,<6.0", "confluent-kafka[avro, schemaregistry]>=2.9.0", "django-temporalio==1.3.1"]
 
 [project.urls]
 Homepage = "https://github.com/RegioHelden/django-kafka"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements-ci.txt
 confluent-kafka[avro, schemaregistry]==2.9.0
 django==5.2
-django-temporalio==1.3.0
+django-temporalio==1.3.1
 ruff==0.11.5
 setuptools==78.1.1  # without it PyCharm fails to index packages inside the Docker container


### PR DESCRIPTION
fix: add forgotten testcases for `ModelMessageProcessor`.