### PR TITLE
fix: consume tombstones immediately instead of queueing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ class MyTopicConsumer(TopicConsumer):
 1. When `TopicConsumer.get_relations` is overwritten, then relations resolver will check for missing relations.
 2. When relation does not exist, then the message is placed to the store for later processing.
 3. When relation exists, but there are waiting messages, then the partition is paused until the messages are consumed.
+4. Tombstones (null message value) are never queued: they discard the waiting messages for the same (topic, key) and are consumed immediately, as the deletion supersedes them and needs no relations. If some of those messages are being resolved at that moment, the partition is paused so the deletion applies strictly after them.
 
 #### Requirements:
 - Current implementation uses Temporal to run background tasks and schedules, but it is possible to implement your own `RelationResolverDaemon` if you want to use something else.

--- a/django_kafka/models/__init__.py
+++ b/django_kafka/models/__init__.py
@@ -100,6 +100,9 @@ class WaitingMessageQuerySet(models.QuerySet):
             serialized_relation=relation.serialize(),
         )
 
+    def for_msg(self, msg: "cimpl.Message"):
+        return self.filter(topic=msg.topic(), key=msg.key())
+
     def for_relation(self, relation):
         # ruff: noqa: PLC0415
         from django_kafka.relations_resolver.relation import ModelRelation

--- a/django_kafka/relations_resolver/processor/base.py
+++ b/django_kafka/relations_resolver/processor/base.py
@@ -28,6 +28,9 @@ class MessageProcessor(ABC):
     ) -> list["Relation"]: ...
 
     @abstractmethod
+    async def adiscard_messages(self, msg: "cimpl.Message"): ...
+
+    @abstractmethod
     async def ato_resolve(self) -> AsyncIterator["Relation"]: ...
 
     @abstractmethod

--- a/django_kafka/relations_resolver/processor/model.py
+++ b/django_kafka/relations_resolver/processor/model.py
@@ -38,16 +38,29 @@ class ModelMessageProcessor(MessageProcessor):
         """Get relations which are still in the WaitingMessage's for current message"""
         return [
             wm.relation()
-            async for wm in self.model.objects.filter(
-                topic=msg.topic(),
-                key=msg.key(),
-            )
+            async for wm in self.model.objects.for_msg(msg)
             .order_by("relation_model_key", "relation_id_field", "relation_id_value")
             .distinct("relation_model_key", "relation_id_field", "relation_id_value")
         ]
 
+    async def adiscard_messages(self, msg: "cimpl.Message"):
+        """
+        Drop queued messages superseded by a tombstone for the same (topic, key).
+
+        Only WAITING messages are discarded: RESOLVING ones are already being
+        replayed by the daemon and must not vanish from under it.
+        """
+        await self.model.objects.for_msg(msg).waiting().adelete()
+
     async def aprocess_messages(self, relation: "Relation"):
         async for msg in await sync_to_async(self.model.objects.for_relation)(relation):
+            # Claim the row before acting on it: the queryset iterates a
+            # snapshot, and a tombstone may have discarded the row since -
+            # a superseded message must not be replayed or re-parked.
+            if not await self.model.objects.filter(pk=msg.pk).aupdate(
+                status=self.model.Status.RESOLVING,
+            ):
+                continue
             kafka_msg = Message(
                 key=msg.key,
                 value=msg.value,

--- a/django_kafka/relations_resolver/resolver.py
+++ b/django_kafka/relations_resolver/resolver.py
@@ -54,6 +54,20 @@ class RelationResolver:
     ) -> Action:
         logger.debug("Check for missing relations.")
 
+        if msg.value() is None:
+            # A tombstone supersedes anything queued for the same (topic, key)
+            # and the deletion itself needs no relations, so it must never wait:
+            # its predecessors may depend on a relation that was cascade-deleted
+            # upstream and will never arrive.
+            await self.processor.adiscard_messages(msg)
+            if await self.processor.awaiting_relations_for(msg):
+                # messages that survived the discard are being replayed by the
+                # daemon right now - the deletion must apply strictly after them
+                logger.debug("Tombstone - predecessors are resolving, pause.")
+                return self.Action.PAUSE
+            logger.debug("Tombstone - queued predecessors discarded, consume.")
+            return self.Action.CONTINUE
+
         for relation in await self.awith_predecessors(relations, msg):
             if not await relation.aexists():
                 logger.debug("Relation is missing - send message to wait.")

--- a/django_kafka/tests/relations_resolver/test_model_processor.py
+++ b/django_kafka/tests/relations_resolver/test_model_processor.py
@@ -1,11 +1,13 @@
 from unittest.mock import AsyncMock, Mock, patch
 
+from asgiref.sync import sync_to_async
 from django.test import TestCase
 
 from django_kafka.exceptions import TopicNotRegisteredError
 from django_kafka.models import WaitingMessage, WaitingMessageQuerySet
 from django_kafka.relations_resolver.processor.model import ModelMessageProcessor
-from django_kafka.tests.utils import AsyncIteratorMock
+from django_kafka.tests.relations_resolver.factories import WaitingMessageFactory
+from django_kafka.tests.utils import AsyncIteratorMock, message_mock
 
 
 class ModelMessageProcessorTestCase(TestCase):
@@ -103,13 +105,13 @@ class ModelMessageProcessorTestCase(TestCase):
         relation_a, relation_b = Mock(), Mock()
         wm1 = Mock(**{"relation.return_value": relation_a})
         wm2 = Mock(**{"relation.return_value": relation_b})
-        qs_distinct = mock_qs.filter.return_value.order_by.return_value.distinct
+        qs_distinct = mock_qs.for_msg.return_value.order_by.return_value.distinct
         qs_distinct.return_value = AsyncIteratorMock([wm1, wm2])
 
         result = await self.msg_processor.awaiting_relations_for(msg)
 
-        mock_qs.filter.assert_called_once_with(topic=msg.topic(), key=msg.key())
-        mock_qs.filter.return_value.order_by.assert_called_once_with(
+        mock_qs.for_msg.assert_called_once_with(msg)
+        mock_qs.for_msg.return_value.order_by.assert_called_once_with(
             "relation_model_key",
             "relation_id_field",
             "relation_id_value",
@@ -120,6 +122,38 @@ class ModelMessageProcessorTestCase(TestCase):
             "relation_id_value",
         )
         self.assertEqual(result, [relation_a, relation_b])
+
+    async def test_adiscard_messages(self):
+        msg = message_mock()
+        relation_kwargs = {
+            "relation_model_key": "example.order",
+            "relation_id_field": "id",
+            "relation_id_value": "1",
+            "serialized_relation": {},
+        }
+        create = sync_to_async(WaitingMessageFactory.create)
+        await create(
+            topic=msg.topic(),
+            key=msg.key(),
+            status=WaitingMessage.Status.WAITING,
+            **relation_kwargs,
+        )
+        resolving = await create(
+            topic=msg.topic(),
+            key=msg.key(),
+            status=WaitingMessage.Status.RESOLVING,
+            **relation_kwargs,
+        )
+        other_key = await create(
+            topic=msg.topic(),
+            status=WaitingMessage.Status.WAITING,
+            **relation_kwargs,
+        )
+
+        await self.msg_processor.adiscard_messages(msg)
+
+        remaining = {wm.id async for wm in WaitingMessage.objects.all()}
+        self.assertEqual(remaining, {resolving.id, other_key.id})
 
     async def test__aget_missing_relation(self):
         existing_relations = [
@@ -158,6 +192,7 @@ class ModelMessageProcessorTestCase(TestCase):
         relation = Mock()
         model_msg = AsyncMock()
 
+        mock_qs.filter.return_value.aupdate = AsyncMock(return_value=1)
         mock_sync_to_async.return_value = AsyncMock(
             return_value=AsyncIteratorMock([model_msg]),
         )
@@ -190,6 +225,7 @@ class ModelMessageProcessorTestCase(TestCase):
         model_msg = AsyncMock()
         missing_relation = Mock()
 
+        mock_qs.filter.return_value.aupdate = AsyncMock(return_value=1)
         mock_sync_to_async.return_value = AsyncMock(
             return_value=AsyncIteratorMock([model_msg]),
         )
@@ -208,6 +244,7 @@ class ModelMessageProcessorTestCase(TestCase):
         )
         model_msg.adelete.assert_called_once_with()
 
+    @patch("django_kafka.models.WaitingMessage.objects")
     @patch(
         "django_kafka.relations_resolver.processor.model.ModelMessageProcessor._aget_missing_relation",
     )
@@ -222,10 +259,12 @@ class ModelMessageProcessorTestCase(TestCase):
         mock_consumers_topic,
         mock_await_for_relation,
         mock__aget_missing_relation,
+        mock_qs,
     ):
         relation = Mock()
         model_msg = AsyncMock()
 
+        mock_qs.filter.return_value.aupdate = AsyncMock(return_value=1)
         sync_to_async_results = [
             # for model.objects.for_relation() call
             AsyncMock(return_value=AsyncIteratorMock([model_msg])),
@@ -242,3 +281,27 @@ class ModelMessageProcessorTestCase(TestCase):
         mock_sync_to_async.assert_any_call(mock_consumers_topic().consume)
         sync_to_async_results[1].assert_any_call(mock_kafka_message())
         model_msg.adelete.assert_called_once_with()
+
+    @patch("django_kafka.models.WaitingMessage.objects")
+    @patch("django_kafka.kafka.consumers.topic")
+    @patch("django_kafka.relations_resolver.processor.model.sync_to_async")
+    async def test_aprocess_messages_skips_discarded(
+        self,
+        mock_sync_to_async,
+        mock_consumers_topic,
+        mock_qs,
+    ):
+        """A row discarded by a tombstone after the queryset snapshot was
+        taken must not be replayed or re-parked."""
+        relation = Mock()
+        model_msg = AsyncMock()
+
+        mock_qs.filter.return_value.aupdate = AsyncMock(return_value=0)
+        mock_sync_to_async.return_value = AsyncMock(
+            return_value=AsyncIteratorMock([model_msg]),
+        )
+
+        await self.msg_processor.aprocess_messages(relation)
+
+        mock_consumers_topic.assert_not_called()
+        model_msg.adelete.assert_not_called()

--- a/django_kafka/tests/relations_resolver/test_resolver.py
+++ b/django_kafka/tests/relations_resolver/test_resolver.py
@@ -69,8 +69,8 @@ class RelationResolverTestCase(SimpleTestCase):
         new_callable=AsyncMock,
     )
     async def test_aresolve_uses_predecessor_relations(self, mock_await_for_relation):
-        """A message with no own relations (e.g. tombstone) must still wait
-        when there are predecessor messages queued for the same (topic, key)."""
+        """A message with no own relations must still wait when there are
+        predecessor messages queued for the same (topic, key)."""
         resolver = RelationResolver()
         msg = message_mock()
 
@@ -85,6 +85,50 @@ class RelationResolverTestCase(SimpleTestCase):
         resolver.processor.awaiting_relations_for.assert_awaited_once_with(msg)
         mock_await_for_relation.assert_called_once_with(msg, predecessor_relation)
         self.assertEqual(action, RelationResolver.Action.SKIP)
+
+    @patch(
+        "django_kafka.relations_resolver.resolver.RelationResolver.await_for_relation",
+        new_callable=AsyncMock,
+    )
+    async def test_aresolve_tombstone_discards_queued_messages(
+        self,
+        mock_await_for_relation,
+    ):
+        """A tombstone supersedes messages queued for the same (topic, key)
+        and is consumed immediately - deletion needs no relations."""
+        resolver = RelationResolver()
+        resolver.processor = MagicMock(
+            adiscard_messages=AsyncMock(),
+            awaiting_relations_for=AsyncMock(return_value=[]),
+        )
+        msg = message_mock(value=None)
+
+        relation = MagicMock(spec=Relation)
+        relation.aexists.return_value = False
+
+        action = await resolver.aresolve([relation], msg)
+
+        resolver.processor.adiscard_messages.assert_awaited_once_with(msg)
+        relation.aexists.assert_not_called()
+        mock_await_for_relation.assert_not_called()
+        self.assertEqual(action, RelationResolver.Action.CONTINUE)
+
+    async def test_aresolve_tombstone_pauses_while_resolving(self):
+        """A tombstone must not overtake messages the daemon is currently
+        replaying - the deletion applies strictly after them."""
+        resolver = RelationResolver()
+        resolver.processor = MagicMock(
+            adiscard_messages=AsyncMock(),
+            awaiting_relations_for=AsyncMock(
+                return_value=[MagicMock(spec=Relation)],
+            ),
+        )
+        msg = message_mock(value=None)
+
+        action = await resolver.aresolve([], msg)
+
+        resolver.processor.adiscard_messages.assert_awaited_once_with(msg)
+        self.assertEqual(action, RelationResolver.Action.PAUSE)
 
     async def test_aresolve_relation(self):
         resolver = RelationResolver()

--- a/django_kafka/tests/utils.py
+++ b/django_kafka/tests/utils.py
@@ -12,6 +12,7 @@ def message_mock(  # noqa: PLR0913
     error=None,
     headers=None,
     timestamp: list[MessageTimestamp, int] | None = None,
+    value=b"value",
 ):
     """mocking utility for confluent_kafka.cimpl.Message"""
     return Mock(
@@ -22,6 +23,7 @@ def message_mock(  # noqa: PLR0913
             "headers.return_value": headers,
             "error.return_value": error,
             "key.return_value": Faker().binary(length=10),
+            "value.return_value": value,
             "timestamp.return_value": timestamp
             or (MessageTimestamp.NOT_AVAILABLE, Faker().unix_time() * 1000),
         },


### PR DESCRIPTION
`MessageProcessor` has a new abstract method `adiscard_messages()` — custom `RELATION_RESOLVER_PROCESSOR` implementations must add it; the built-in `ModelMessageProcessor` is unaffected.