### PR TITLE
Library updates, make ssh keys and git config available in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,18 @@
     "workspaceFolder": "/app",
     // set the remote user to connect as
     "remoteUser": "app",
+    // mount ssh folder and git config to be able to use ssh keys for commit signing
+    // see https://dev.wiki.regiohelden.de/git/ for more details
+    // make sure to use relative paths to the home directory in your configs!
+    "mounts": [
+        "source=${localEnv:HOME}/.ssh,target=/home/app/.ssh,type=bind,readonly",
+        "source=${localEnv:HOME}/.config/git,target=/home/app/.config/git,type=bind,readonly"
+    ],
+    // initialize command to create the mount points for ssh and git config
+    // if they don't exist to prevent mount errors
+    "initializeCommand": {
+        "mkdir-mount": "mkdir -p /home/app/.ssh /home/app/.config/git || true"
+    },
     // features to be installed in the dev container
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2.5.9": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -172,7 +172,7 @@
                 "aaron-bond.better-comments",
                 // Linting with ruff
                 // https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff
-                "charliermarsh.ruff@2026.56.0",
+                "charliermarsh.ruff@2026.68.0",
                 // ---------------------------------------
                 // GIT
                 // ---------------------------------------

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         "ghcr.io/devcontainers/features/common-utils:2.5.9": {},
         "ghcr.io/devcontainers/features/git:1.3.7": {},
         "ghcr.io/devcontainers-extra/features/ruff:2.0.0": {
-            "version": "0.15.20"
+            "version": "0.16.1"
         },
         "ghcr.io/devcontainers-extra/features/ty:1.0.0": {
             "version": "0.0.56"
@@ -157,7 +157,7 @@
                 "ms-python.python",
                 // ty - A fast Python language server and linter written in Rust
                 // https://marketplace.visualstudio.com/items?itemName=astral-sh.ty
-                "astral-sh.ty@2026.60.0",
+                "astral-sh.ty@2026.64.0",
                 // Python docstring generator
                 // https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring
                 "njpwerner.autodocstring",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,12 +21,12 @@
     // features to be installed in the dev container
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2.5.9": {},
-        "ghcr.io/devcontainers/features/git:1.3.7": {},
+        "ghcr.io/devcontainers/features/git:1.3.8": {},
         "ghcr.io/devcontainers-extra/features/ruff:2.0.0": {
             "version": "0.16.1"
         },
         "ghcr.io/devcontainers-extra/features/ty:1.0.0": {
-            "version": "0.0.56"
+            "version": "0.0.65"
         }
     },
     // configure vscode

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -34,12 +34,12 @@ jobs:
       - build-and-release
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Download the distribution packages
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,4 +18,4 @@ jobs:
       contents: read
     uses: RegioHelden/github-reusable-workflows/.github/workflows/python-ruff.yaml@v2.9.0
     with:
-      ruff-version: "0.15.20"
+      ruff-version: "0.16.1"

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ htmlcov
 .bash_history
 compose.override.yaml
 
+# vscode
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
+.devcontainer/devcontainer-lock.json
+
 # Language specific
 __pycache__
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --chown=app requirements* /app/
 
 ENV PATH=/home/app/.local/bin:/home/app/venv/bin:${PATH} DJANGO_SETTINGS_MODULE=example.settings
 
-RUN pipx install --force uv==0.11.26 && \
+RUN pipx install --force uv==0.12.1 && \
     uv venv ~/venv --clear && \
     uv pip install --no-cache --upgrade --requirements /app/requirements-test.txt && \
     uv cache clean

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Considering you have locally setup kafka instance with no authentication. All yo
 # ./settings.py
 
 INSTALLED_APPS = [
-  # ...
-  "django_kafka",
+    ...
+    "django_kafka",
 ]
 
 DJANGO_KAFKA = {
     "GLOBAL_CONFIG": {
-      "bootstrap.servers": "kafka1:9092",
+        "bootstrap.servers": "kafka1:9092",
     },
 }
 ```
@@ -96,7 +96,7 @@ Message are produced using a Topic instance.
 ```python
 from my_app.topics import Topic1
 
-# this will send a message to kafka, serializing it using the defined serializer 
+# this will send a message to kafka, serializing it using the defined serializer
 Topic1().produce("some message")
 ```
 Check [Confluent Python Producer](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#producer) for API documentation.
@@ -110,7 +110,7 @@ Find available configs in the [SchemaRegistryClient docs](https://docs.confluent
 ```python
 DJANGO_KAFKA = {
     "SCHEMA_REGISTRY": {
-      "url": "http://schema-registry",
+        "url": "http://schema-registry",
     },
 }
 ```
@@ -128,6 +128,7 @@ from django_kafka.topic.model import ModelTopicConsumer
 
 from my_app.models import MyModel
 
+
 class MyModelConsumer(ModelTopicConsumer):
     name = "topic"
     model = MyModel
@@ -141,11 +142,11 @@ Model instances will have their attributes synced from the message value.
 ```python
 class MyModelConsumer(ModelTopicConsumer):
     ...
-        
-    exclude_fields = ['id']
+
+    exclude_fields = ["id"]
 
     def transform_name(model, key, value):
-        return 'first_name', value["name"].upper()
+        return "first_name", value["name"].upper()
 ```
 
 A few notes:
@@ -179,7 +180,9 @@ class MyModelTopic(AvroTopicProducer, TopicReproducer):
     reproduce_model = MyModel
 
     def _reproduce_upsert(self, instance, key, value):
-        self.produce(key={"id": instance.id}, value={**value, 'extra': 1}) # add extra data to value as necessary
+        self.produce(
+            key={"id": instance.id}, value={**value, "extra": 1}
+        )  # add extra data to value as necessary
 
     def _reproduce_deletion(self, instance_id, key, value):
         self.produce(key={"id": instance_id}, value=None)
@@ -189,6 +192,7 @@ class MyModelTopic(AvroTopicProducer, TopicReproducer):
 from django_kafka import kafka
 from django_kafka.consumer import Consumer, Topics
 from .topics import MyModelTopic
+
 
 @kafka.consumers()
 class MyTopicReproducerConsumer(Consumer):
@@ -262,7 +266,6 @@ from django_kafka.relations_resolver.relation import ModelRelation
 
 
 class MyTopicConsumer(TopicConsumer):
-
     def get_relations(self, msg: "cimpl.Message"):
         value = self.deserialize(msg.value(), MessageField.VALUE, msg.headers())
         yield ModelRelation(Order, id_value=value["customer_id"], id_field="id")
@@ -398,7 +401,10 @@ Provide explicit `Relation` entries only to customise auto-detection: non-defaul
 
 ```python
 from django_kafka.models.model_sync import (
-    IncludeFields, ModelSync, PythonAvroSink, Relation,
+    IncludeFields,
+    ModelSync,
+    PythonAvroSink,
+    Relation,
 )
 from my_app.models import Customer, Order
 
@@ -410,8 +416,9 @@ class OrderSync(ModelSync):
     sink = PythonAvroSink(
         relations=[
             # non-default id_field + renamed value_field after enrich transform
-            Relation(Customer, id_field="uuid",
-                     value_field="customer__uuid", fk="customer"),
+            Relation(
+                Customer, id_field="uuid", value_field="customer__uuid", fk="customer"
+            ),
         ],
     )
 ```
@@ -420,8 +427,13 @@ class OrderSync(ModelSync):
 
 ```python
 from django_kafka.models.model_sync import (
-    DbzPostgresSource, IncludeFields, MessagePart, ModelSync,
-    PythonAvroSink, Relation, SyncMethodTransform,
+    DbzPostgresSource,
+    IncludeFields,
+    MessagePart,
+    ModelSync,
+    PythonAvroSink,
+    Relation,
+    SyncMethodTransform,
 )
 from my_app.models import Customer, Order
 
@@ -433,8 +445,9 @@ class OrderSync(ModelSync):
     source = DbzPostgresSource(msg_key_fields=["customer_id", "status"])
     sink = PythonAvroSink(
         relations=[
-            Relation(Customer, id_field="uuid",
-                     value_field="customer__uuid", fk="customer"),
+            Relation(
+                Customer, id_field="uuid", value_field="customer__uuid", fk="customer"
+            ),
         ],
     )
 
@@ -690,8 +703,7 @@ from django_kafka import producer
 
 
 @producer.suppress(["topic1"])  # suppress producers to topic1
-def my_function():
-    ...
+def my_function(): ...
 
 
 def my_function_two():
@@ -767,8 +779,8 @@ The `produce.suppress` decorator can be used to suppress messages produced durin
 from django_kafka import producer
 from django_kafka.consumer import Consumer
 
+
 class MyConsumer(Consumer):
-    
     @producer.suppress
     def consume(self, *args, **kwargs):
         super().consume(*args, **kwargs)

--- a/django_kafka/tests/utils.py
+++ b/django_kafka/tests/utils.py
@@ -5,7 +5,7 @@ from faker import Faker
 from django_kafka.utils.message import MessageTimestamp
 
 
-def message_mock(  # noqa: PLR0913
+def message_mock(  # noqa: PLR0913, PLR0917
     topic="topic",
     partition=0,
     offset=0,

--- a/django_kafka/utils/message.py
+++ b/django_kafka/utils/message.py
@@ -49,8 +49,7 @@ class Message:
     https://github.com/confluentinc/confluent-kafka-python/issues/1535
     """
 
-    # ruff: noqa: PLR0913
-    def __init__(
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         topic: str,
         key: bytes | str,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,5 @@
 confluent-kafka[avro, schemaregistry]==2.15.0
 django==6.0.6
 django-temporalio==2.0.0
-ruff==0.15.19
+ruff==0.16.1
 setuptools==83.0.0  # without it PyCharm fails to index packages inside the Docker container


### PR DESCRIPTION
Update from RegioHelden's modulesync-config-django

- VSCode feature git to 1.3.8
- ruff to 0.16.1
- ruff VSCode extension to 2026.68.0
- ty to 0.0.65
- ty VSCode extension to 2026.64.0
- actions/setup-python to 7.0.0
- astral-sh/setup-uv to 9.0.0
- uv to 0.12.1