### PR TITLE
revert "fix: use the value first to obtain the lookup ID in ModelTopicConsumer.get_lookup_kwargs, refs #338"

### DIFF
--- a/django_kafka/tests/test_topic/test_model.py
+++ b/django_kafka/tests/test_topic/test_model.py
@@ -17,6 +17,12 @@ class ModelTopicConsumerTestCase(AbstractModelTestCase):
             name = "name"
             model = self.model
 
+            def get_lookup_kwargs(self, model, key, value) -> dict:
+                return {}
+
+            def is_deletion(self, *args, **kwargs):
+                return False
+
         return SomeModelTopicConsumer()
 
     def test_get_defaults(self):
@@ -34,39 +40,6 @@ class ModelTopicConsumerTestCase(AbstractModelTestCase):
         )
 
         self.assertEqual(defaults, {"name": 1})
-
-    def test_get_lookup_kwargs__pk_in_value(self):
-        """test the PK is taken from the value when available"""
-        topic_consumer = self._get_model_topic_consumer()
-        lookup = topic_consumer.get_lookup_kwargs(
-            self.model,
-            {"name": "key"},
-            {"id": 1},
-        )
-
-        self.assertEqual(lookup, {"id": 1})
-
-    def test_get_lookup_kwargs__pk_in_key(self):
-        """test the PK is taken from the key when it's not possible from the value"""
-        topic_consumer = self._get_model_topic_consumer()
-        lookup = topic_consumer.get_lookup_kwargs(
-            self.model,
-            {"id": 1},
-            {"name": "value"},
-        )
-
-        self.assertEqual(lookup, {"id": 1})
-
-    def test_get_lookup_kwargs__whole_key_when_no_pk(self):
-        """test the lookup kwargs is the whole key when the PK is not available"""
-        topic_consumer = self._get_model_topic_consumer()
-        lookup = topic_consumer.get_lookup_kwargs(
-            self.model,
-            {"name": "key", "name2": "key2"},
-            {"name": "value"},
-        )
-
-        self.assertEqual(lookup, {"name": "key", "name2": "key2"})
 
     def test_transform(self):
         """test custom transform methods are used during transformation"""

--- a/django_kafka/topic/model.py
+++ b/django_kafka/topic/model.py
@@ -67,11 +67,7 @@ class ModelTopicConsumer(TopicConsumer, ABC):
 
     def get_lookup_kwargs(self, model, key, value) -> dict:
         """returns the lookup kwargs used for filtering the model instance"""
-        # obtain the pk from the value first so the key can be adjusted for partitioning
-        pk_field = model._meta.pk.name
-        if value and pk_field in value:
-            return {pk_field: value[pk_field]}
-        if pk_field in key:
+        if (pk_field := model._meta.pk.name) in key:
             return {pk_field: key[pk_field]}
         return key
 


### PR DESCRIPTION
This commit actually can actually cause breaking changes that are hard to override.

Come back to this when it's easier to control the lookup behaviour.